### PR TITLE
Ignore Struct Keys From Being Stringified

### DIFF
--- a/lib/key_tools.ex
+++ b/lib/key_tools.ex
@@ -127,6 +127,7 @@ defmodule KeyTools do
   iex(2)> stringify_keys [%{atom_key: %{42 => [%{another_key: 23}]}}]
   [%{"atom_key" => %{"42" => [%{"another_key" => 23}]}}]
   """
+  def stringify_keys(%{__struct__: _}=struct), do: struct
   def stringify_keys(map) when is_map(map) do
     for {key, value} <- map, into: %{}, do: {to_string(key), stringify_keys(value)}
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule KeyTools.Mixfile do
   defp deps do
     [
       {:mix_test_watch, "~> 0.2", only: :dev},
-      {:ex_doc, "~> 0.12", only: :dev}
+      {:ex_doc, "~> 0.12", only: :dev},
+      {:decimal, "~> 1.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
+%{"decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
+  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]}}

--- a/test/key_tools_test.exs
+++ b/test/key_tools_test.exs
@@ -128,5 +128,10 @@ defmodule KeyToolsTest do
       assert stringify_keys(42) == 42
       assert stringify_keys("string") == "string"
     end
+
+    test "ignores structs from being altered" do
+      decimal = Decimal.new(7)
+      assert stringify_keys(decimal) == decimal
+    end
   end
 end


### PR DESCRIPTION
Because Elixir structs can represent complex data types via Protocols
their key/value pairs are not enumerable.  This leads to problems when
attempting to stringify maps that may hold some structs in it.  Before
this commit the behavior of the code was it would raise an exception
when it met such data:

```
** (Protocol.UndefinedError) protocol Enumerable not implemented for #Decimal<7>
```

Instead of failing this elects to leave structs alone as they do not
function the same as normal maps but unforunately pass such guard
clauses as `is_map`.